### PR TITLE
fixed the width in languages that use comma in decimal separator

### DIFF
--- a/Input/src/NotchedOutline/NotchedOutline.cs
+++ b/Input/src/NotchedOutline/NotchedOutline.cs
@@ -4,6 +4,7 @@ using Skclusive.Material.Form;
 using System.Linq;
 using Skclusive.Core.Component;
 using System;
+using System.Globalization;
 
 namespace Skclusive.Material.Input
 {
@@ -71,7 +72,8 @@ namespace Skclusive.Material.Input
                 foreach (var item in base.Styles)
                     yield return item;
 
-                yield return Tuple.Create<string, object>("width", $"{(Notched ? _LabelWidth : 0.01)}px");
+                var finalWidth = Notched ? _LabelWidth : 0.01;
+                yield return Tuple.Create<string, object>("width", $"{finalWidth.ToString(CultureInfo.InvariantCulture)}px");
             }
         }
 


### PR DESCRIPTION
Some countries use a comma in the decimal separator, which makes the width an incorrect value. For example: "width: 45,5px".

This change guarantees that the dot will be used as a decimal separator in the label.