### PR TITLE
Dismiss Modals and Menus on "right click" too

### DIFF
--- a/Modal/src/SimpleBackdrop/SimpleBackdrop.razor
+++ b/Modal/src/SimpleBackdrop/SimpleBackdrop.razor
@@ -8,6 +8,8 @@
     style="@_Style"
     aria-hidden
     @onclick="HandleClickAsync"
+    @oncontextmenu="HandleClickAsync"
+    @oncontextmenu:preventDefault="true"
     @attributes="Attributes">
     @ChildContent?.Invoke(Context)
 </div>


### PR DESCRIPTION
`Modals` and `Menus` don't dismiss for right-clicks, only left-clicks. I think this change makes the behavior more consistent (a click is a click), but it also make the UX nicer when doing right-click context menus.

Before the change:

![before](https://user-images.githubusercontent.com/123988/98101554-421ec400-1ef7-11eb-8e3d-3c68012e7201.gif)

After the change:

![after](https://user-images.githubusercontent.com/123988/98101567-477c0e80-1ef7-11eb-9c63-2f8180fb698d.gif)
