### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = crlf
 insert_final_newline = false
 trim_trailing_whitespace = true
 indent_size = 4
+
+[*.{cs,razor}]
+dotnet_diagnostic.CA1304.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,9 @@ insert_final_newline = false
 trim_trailing_whitespace = true
 indent_size = 4
 
+[*.{xml,csproj}]
+indent_size = 2
+insert_final_newline = true
+
 [*.{cs,razor}]
 dotnet_diagnostic.CA1304.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+﻿# This file is the top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8-bom
+indent_style = space
+end_of_line = crlf
+insert_final_newline = false
+trim_trailing_whitespace = true
+indent_size = 4

--- a/Button/src/ButtonBase/ButtonBase.razor.cs
+++ b/Button/src/ButtonBase/ButtonBase.razor.cs
@@ -56,7 +56,7 @@ namespace Skclusive.Material.Button
 
         protected bool LastDisabled { set; get; }
 
-        protected string _Type => _Component == "button" ? Type.ToString().ToLower() : null;
+        protected string _Type => _Component == "button" ? Type.ToString().ToLowerInvariant() : null;
 
         protected bool Navigation => !string.IsNullOrWhiteSpace(Href) && _Component == "a";
 

--- a/Input/src/InputLabel/InputLabel.razor.cs
+++ b/Input/src/InputLabel/InputLabel.razor.cs
@@ -42,7 +42,7 @@ namespace Skclusive.Material.Input
 
         protected bool _Shrink => Shrink.HasValue ? Shrink.Value : ((_Filled.HasValue && _Filled.Value) || (_Focused.HasValue && _Focused.Value) || (_HasStartAdornment.HasValue && _HasStartAdornment.Value));
 
-        protected string DataShrink => _Shrink.ToString().ToLower();
+        protected string DataShrink => _Shrink.ToString().ToLowerInvariant();
 
         protected override IEnumerable<string> Classes
         {

--- a/Skclusive.Material.Component.sln
+++ b/Skclusive.Material.Component.sln
@@ -139,6 +139,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Link", "Link", "{F3262C3E-F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Link", "Link\src\Link.csproj", "{99B30DAF-C3DF-4A92-A374-FBAA7BE3AE21}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Globals", "Globals", "{64BE657C-D1C8-4A96-A565-152DE0B0A4C0}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Transition/src/SlideHelper/SlideHelper.cs
+++ b/Transition/src/SlideHelper/SlideHelper.cs
@@ -17,7 +17,7 @@ namespace Skclusive.Material.Transition
         {
             if (element.HasValue)
             {
-                return await ScriptService.InvokeAsync<string>("Skclusive.Material.Transition.getSlideTranslateValue", placement.ToString().ToLower(), element);
+                return await ScriptService.InvokeAsync<string>("Skclusive.Material.Transition.getSlideTranslateValue", placement.ToString().ToLowerInvariant(), element);
             }
 
             return null;
@@ -27,7 +27,7 @@ namespace Skclusive.Material.Transition
         {
             if (element.HasValue)
             {
-                await ScriptService.InvokeVoidAsync("Skclusive.Material.Transition.setSlideTranslateValue", placement.ToString().ToLower(), element);
+                await ScriptService.InvokeVoidAsync("Skclusive.Material.Transition.setSlideTranslateValue", placement.ToString().ToLowerInvariant(), element);
             }
         }
     }


### PR DESCRIPTION
Coming from #71, this adds an `.editorconfig` at the repository root with some defaults as observed from existing code. I added the file to the solution in the sub-folder `Globals`.

Rule `CA1304` is configured as an error. All erroneous places are fixed.

I couldn't figure out how to analyze Razor files as well, so the advantage of this is very limited, unfortunately. I also tried the following with no success.

```
[*.razor.g.cs]
generated_code = false
dotnet_diagnostic.CA1304.severity = error
```

It might be a good idea to add dotnet naming rules to make it easier for others to contribute without running into formatting issues.
